### PR TITLE
修复多次配置时TCPCom的RecNewData被多次绑定的问题和COMTool界面与串口相关的部分bug

### DIFF
--- a/api/RepeaterWidget/RepeaterWidget.cpp
+++ b/api/RepeaterWidget/RepeaterWidget.cpp
@@ -27,6 +27,11 @@ void RepeaterWidget::SaveConstructConfig() {
 
 void RepeaterWidget::StopAllInfoTCP() {
     if (tcp_info_handler_[1] == nullptr) { return; }
+    if (tcp_info_handler_[2] == nullptr) { return; }
+    if (tcp_info_handler_[3] == nullptr) { return; }
+    disconnect(tcp_info_handler_[1], &TCPInfoHandle::RecNewData, 0, 0);
+    disconnect(tcp_info_handler_[2], &TCPInfoHandle::RecNewData, 0, 0);
+    disconnect(tcp_info_handler_[3], &TCPInfoHandle::RecNewData, 0, 0);
     if (tcp_info_handler_[1]->is_connected_) {
         tcp_info_handler_[1]->disconnectFromHost();
     }

--- a/components/ComTool/Comtool.cpp
+++ b/components/ComTool/Comtool.cpp
@@ -251,7 +251,12 @@ void ComTool::ReflashComCombo() {
     timer_for_port_->start();
 }
 
-bool ComTool::StartSerial() {
+bool ComTool::OpenSerial() {
+    if(ui_->COMCombo->currentText()=="")
+    {
+        emit(OrderShowSnackbar("没有有效的串口"));
+        return false;
+    }
     qDebug() << ui_->COMCombo->currentText();
     my_serialport_->setPortName(ui_->COMCombo->currentText());
     my_serialport_->setBaudRate(baud_rate_);
@@ -268,6 +273,8 @@ bool ComTool::StartSerial() {
         return true;
     } else {
         qDebug() << my_serialport_->error();
+        my_serialport_->close();
+        emit(OrderShowSnackbar("串口打开失败，请检查是否被占用或权限不足"));
         return false;
     }
 }
@@ -290,7 +297,8 @@ void ComTool::StartTool() {
 
     } else {
         if (ui_->COMButton->isChecked()) {
-            StartSerial();
+            if(!OpenSerial())
+                return;
         }
 
         ui_->COMButton->setEnabled(false);
@@ -379,7 +387,7 @@ void ComTool::GetData() {
 ///发送发送栏里的数据
 void ComTool::SendData() {
     if (!is_start_) {
-        QMessageBox::warning(this, tr("错误"), tr("请先打开串口后再发送"));
+        emit(OrderShowSnackbar("请先打开串口再发送"));
         return;
     }
 

--- a/components/ComTool/Comtool.h
+++ b/components/ComTool/Comtool.h
@@ -78,7 +78,7 @@ class ComTool : public RepeaterWidget {
 
     QStringList GetPortInfo();
     void ReflashComCombo();
-    bool StartSerial();
+    bool OpenSerial();
     QStringList my_serialportinfo_ = {};
 
     QSerialPort *my_serialport_;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -152,8 +152,10 @@ void MainWindow::DeviceWindowsInit() {
                     devices_info_[device_num].tab_widget->addTab("通道配置");  // 添加tab栏
                     break;
                 case 50:devices_windows_info_[device_num][win_num].type = COM_TOOL;  // 结构体初始化
-                    devices_windows_info_[device_num][win_num].widget =
+                    tmp_widget =
                         new ComTool(device_num, win_num, config_device_ini_[device_num], &parent_info_);
+                    ConnectSingal(tmp_widget);
+                    devices_windows_info_[device_num][win_num].widget = tmp_widget;
                     devices_windows_info_[device_num][win_num].index =
                         ui_->FunctionWindow->addWidget(devices_windows_info_[device_num][win_num].widget);
                     devices_info_[device_num].tab_widget->addTab("本地串口监视器");  // 添加tab栏

--- a/structH.h
+++ b/structH.h
@@ -40,7 +40,7 @@ struct WindowsInfo {
 
 //设备配置信息结构体
 struct DevicesInfo {
-    int connect_mode=0;
+    int connect_mode=0;//0:无,1:调试器,2:COM,3:TCP
     int windows_num=-1;
     int tab_index=-1;
     QtMaterialTabs *tab_widget{};


### PR DESCRIPTION
修复了COMTool界面在没选中任何串口时仍能打开串口
修复了COMTool打不开时报错但不阻止用户的情况
修复多次配置时TCPCom的RecNewData被多次绑定的问题

新增了串口打开失败的提醒方式为Snackbar